### PR TITLE
feat(theme.ts): allow SymbolLayer type to display edit icons

### DIFF
--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -4,7 +4,8 @@ import type {
   CircleLayerSpecification,
   FillLayerSpecification,
   LineLayerSpecification,
-} from "maplibre-gl";
+  SymbolLayerSpecification,
+} from 'maplibre-gl';
 
 const blue = "#3bb2d0";
 const orange = "#fbb03b";
@@ -38,9 +39,10 @@ export type ThemeLayerId =
 
 export type Theme = Array<
   (
-    | Partial<FillLayerSpecification>
+     Partial<FillLayerSpecification>
     | Partial<LineLayerSpecification>
     | Partial<CircleLayerSpecification>
+    | Partial<SymbolLayerSpecification>
   ) & { id: ThemeLayerId }
 >;
 


### PR DESCRIPTION
Hi, using icons as edit handles works great and this should fix the type error I get using these custom styles:
```typescript
{
  id: 'gl-draw-vertex-inner',
  type: 'symbol',
  filter: ['all', ['==', '$type', 'Point'], ['==', 'meta', 'vertex'], ['!=', 'mode', 'simple_select']],
  layout: {
      'icon-allow-overlap': true,
      'icon-image': ['case', ['==', ['get', 'active'], 'true'], 'map-edit-active', 'map-edit-inactive'],
      'icon-size': 1,
      'icon-rotation-alignment': 'viewport',
  },
},

{
  id: 'gl-draw-midpoint',
  type: 'symbol',
  filter: ['all', ['==', 'meta', 'midpoint']],
  layout: {
      'icon-allow-overlap': true,
      'icon-image': 'map-edit-inactive',
      'icon-size': 0.8,
      'icon-rotation-alignment': 'viewport',
  },
},
```

Btw, do you have an idea why it is grey instead of white like my original icon?
Setting  `paint: { 'icon-opacity': 1}` does not help.

<img width="671" alt="Screenshot 2025-03-24 at 22 23 43" src="https://github.com/user-attachments/assets/56ac7e50-8acd-48be-8b11-07f5596196a6" />


